### PR TITLE
fix(js): allow pinning importmaps with gem

### DIFF
--- a/lib/turbo_boost/streams/engine.rb
+++ b/lib/turbo_boost/streams/engine.rb
@@ -5,9 +5,20 @@ require_relative "version"
 require_relative "patches"
 
 class TurboBoost::Engine < ::Rails::Engine
+  config.turbo_boost_streams = ActiveSupport::OrderedOptions.new
+  config.turbo_boost_streams.precompile_assets = true
+
   config.after_initialize do
     ::Turbo::Streams::TagBuilder.send :include, TurboBoost::Streams::Patches::TagBuilder
     ::Turbo::Streams::Broadcasts.send :include, TurboBoost::Streams::Patches::Broadcasts
     ::Turbo::Broadcastable.send :include, TurboBoost::Streams::Patches::Broadcastable
+  end
+
+  initializer "turbo_boost_streams.asset" do
+    config.after_initialize do |app|
+      if app.config.respond_to?(:assets) && app.config.turbo_boost_streams.precompile_assets
+        app.config.assets.precompile += %w[@turbo-boost/streams.js]
+      end
+    end
   end
 end


### PR DESCRIPTION
Since import maps JSPM and the javascript ecosystem are a mess in their current state, allow import maps to match the assets served by the gem rather than download them from JSPM.

@hopsoft I will test this and reply if it works, but according to ChatGPT and the action cable source code, this is how it could be done. It may only work for my scenario, but I unblock myself this way. 

```ruby
pin "@turbo-boost/streams", to: "@turbo-boost/streams.js", preload: false
pin "@turbo-boost/commands", to: "@turbo-boost/commands.js", preload: false
pin "@turbo-boost/elements", to: "@turbo-boost/elements.js", preload: false
pin "alpinejs", preload: false # @3.13.5
pin "@alpinejs/morph", to: "@alpinejs--morph.js", preload: false # @3.13.5
```

That fixes that problem; I'm happy with this solution for now; seems fair since JSPM never updates. Perhaps we can update the documentation for importmaps to the following:

1. https://github.com/hopsoft/turbo_boost-streams/pull/51
2. https://github.com/hopsoft/turbo_boost-commands/pull/122
3. https://github.com/hopsoft/turbo_boost-elements/pull/49

This is verified to be working with: 

```ruby
gem "turbo_boost-streams",  github: "mhenrixon/turbo_boost-streams"
gem "turbo_boost-commands", github: "mhenrixon/turbo_boost-commands"
gem "turbo_boost-elements", github: "mhenrixon/turbo_boost-elements"
```